### PR TITLE
refactor: change package name to JS, not zollinger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 version = "0.0.1"
-group = "com.jonathanzollinger.justserve"
+group = "org.justserve.helpcenter"
 
 val kotlinVersion= project.properties["kotlinVersion"]
 repositories {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("java")
 }
 
-group = "com.jonathanzollinger.justserve"
+group = "org.justserve.helpcenter"
 version = "0.1"
 
 repositories {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 version = "0.0.1"
-group = "com.jonathanzollinger.justserve"
+group = "org.justserve.helpcenter"
 
 val kotlinVersion= project.properties["kotlinVersion"]
 repositories {

--- a/core/src/main/kotlin/justserve/helpcenter/Application.kt
+++ b/core/src/main/kotlin/justserve/helpcenter/Application.kt
@@ -1,4 +1,4 @@
-package jonathanzollinger
+package justserve.helpcenter
 
 import io.micronaut.runtime.Micronaut.run
 fun main(args: Array<String>) {

--- a/core/src/test/groovy/justserve/helpcenter/JustServeSpec.groovy
+++ b/core/src/test/groovy/justserve/helpcenter/JustServeSpec.groovy
@@ -1,4 +1,4 @@
-package jonathanzollinger
+package justserve.helpcenter
 
 import io.micronaut.runtime.EmbeddedApplication
 import io.micronaut.test.extensions.spock.annotation.MicronautTest


### PR DESCRIPTION
rename the packages to reflect the justserve package name instead of the zollinger package name